### PR TITLE
Fix Pydantic model config depreciation warning

### DIFF
--- a/src/tagflow/tagflow.py
+++ b/src/tagflow/tagflow.py
@@ -36,7 +36,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import (
@@ -602,8 +602,7 @@ class Session(BaseModel):
     send_channel: MemoryObjectSendStream[Transaction]
     transaction_receiver: MemoryObjectReceiveStream[Transaction]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @asynccontextmanager
     async def transition(self):


### PR DESCRIPTION
Tagflow is generating a warning because the `Session` Pydantic model is using a class-based config, which is now [deprecated](https://docs.pydantic.dev/2.10/migration/#changes-to-config) 

```
.venv/lib/python3.12/site-packages/pydantic/_internal/_config.py:295
  /Users/fvoron/Development/tagflow/.venv/lib/python3.12/site-packages/pydantic/_internal/_config.py:295: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```

This PR simply updates it to the new syntax, which removes the warning.